### PR TITLE
Added a report environment to the tox.ini file and a --skip-existing command to the cofig.yml file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
              . venv/bin/activate
             pip3 install --upgrade pip
             pip3 install twine
-            twine upload dist/*
+            twine upload --skip-existing dist/*
       - run:
           name: executing ansible to a remote server
           command: |

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,10 @@ description ={envpython}
 deps =
     pytest
     flake8
+
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report


### PR DESCRIPTION
In the tox.ini file i added a report environment to ensure that the coverage was displayed at the moment the test is carried out. I also used the --skip-existing command at the deploy job when publishing to pypi to ensure that the version didn't have to be changed on every push to git   