### PR TITLE
Added a hold and approval step in the workflow and added an extra publish job to the jobs performed by circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
       - hold:
           type: approval
           requires:
-            test
+            - test
       - publish:
           requires:
             - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,9 @@ jobs:
       - store_artifacts:
           path: test-results
 
-  deploy:
+  publish:
     docker:
       - image: circleci/python:3.6.4
-    environment:
-      - ANSIBLE_HOST_KEY_CHECKING: False
     steps:
       - checkout
       - run:
@@ -58,6 +56,14 @@ jobs:
             pip3 install --upgrade pip
             pip3 install twine
             twine upload --skip-existing dist/*
+
+  deploy:
+    docker:
+      - image: circleci/python:3.6.4
+    environment:
+      - ANSIBLE_HOST_KEY_CHECKING: False
+    steps:
+      - checkout
       - run:
           name: executing ansible to a remote server
           command: |
@@ -68,12 +74,23 @@ jobs:
 
 workflows:
   version: 2
-  test_deploy:
+  test-and-approval-publish-and-approval-deploy:
     jobs:
       - test
-      - deploy:
+      - hold:
+          type: approval
           requires:
-            - test
+            test
+      - publish:
+          requires:
+            - hold
           filters:
             branches:
               only: master
+      - deploy:
+          requires:
+            - hold
+          filters:
+            branches:
+              only: master
+


### PR DESCRIPTION
I added  a hold step in my workflow to ensure that approval was given for the application to be published in pip registry and to be deployed to the server. I also added a hyphen before the test job tht is required by the hold workflow to run.